### PR TITLE
Add an external ID

### DIFF
--- a/user-manual/reports/report-template-variables.md
+++ b/user-manual/reports/report-template-variables.md
@@ -12,11 +12,11 @@ When you are designing your pentest project template, you can reference a number
 |-|-|-|
 |date|Current date (dd/mm/yyyy)|(n/a)|
 |org|Your org information|name, url, contact_name, contact_email, contact_phone|
-|project|Project information|name, description, engagement_type, engagement_start_date, engagement_end_date|
+|project|Project information|name, description, engagement_type, engagement_start_date, engagement_end_date, external_id|
 |client|Project's client|name, address, url, contact_name, contact_email, contact_phone|
 |users|Project's users|full_name, short_bio, email, role|
 |targets|Project's targets|name, kind, tags|
 |findingsOverview|Findings stats|severity, count|
-|vulnerabilities|Project's vulnerabilities|summary, description, risk, remediation, status, cvss_score, cvss_vector|
+|vulnerabilities|Project's vulnerabilities|summary, description, risk, remediation, status, cvss_score, cvss_vector, proof_of_concept|
 |revisionHistoryDateTime|Report's revisions|dateTime, versionName, versionDescription|
 


### PR DESCRIPTION
## Description
This small change adds a new field named 'external ID' into the Project. It provides an opportunity to link the report with the external evidence of realised projects. Since this field is intended to be unique for each project, I did not add it to the Project templates.

## Examples

### Create and edit project
![project](https://user-images.githubusercontent.com/2551605/151332981-47d77208-3e83-4227-93e3-37efdeca7034.gif)

### Create report
![report](https://user-images.githubusercontent.com/2551605/151333027-6ec981fb-1d6e-47f7-a88b-da91cf40ab8c.gif)


