### PR TITLE
Added logos among report template variables

### DIFF
--- a/user-manual/reports/report-template-variables.md
+++ b/user-manual/reports/report-template-variables.md
@@ -11,9 +11,9 @@ When you are designing your pentest project template, you can reference a number
 |Variable|Description|Attributes|
 |-|-|-|
 |date|Current date (dd/mm/yyyy)|(n/a)|
-|org|Your org information|name, url, contact_name, contact_email, contact_phone|
+|org|Your org information|name, url, contact_name, contact_email, contact_phone, logo, small_logo|
 |project|Project information|name, description, engagement_type, engagement_start_date, engagement_end_date, external_id|
-|client|Project's client|name, address, url, contact_name, contact_email, contact_phone|
+|client|Project's client|name, address, url, contact_name, contact_email, contact_phone, logo, small_logo|
 |users|Project's users|full_name, short_bio, email, role|
 |targets|Project's targets|name, kind, tags|
 |findingsOverview|Findings stats|severity, count|


### PR DESCRIPTION
This enhancement is about introducing logos to the client and organisation. The main goal is to enable customization of the report, so it can contain necessary logo's. There are two variants for each, so the smaller one can be used in the footer of the report and the main logon on the introduction page.
As we discussed in the private chat, I re-used attachment functionality. I enhanced it, so it can update the existing attachment (logo in our case, but I tried to write it as generic as possible).

I am not sure with the UI (web part). It will probably require some changes to make it more nice looking. I feel like there is a room for improvement, but right now, I cannot say what exactly I do not like about it.

The basic behavior is shown on these GIFs.

![01_create_and_update_logo_organisation](https://user-images.githubusercontent.com/2551605/154867538-e37588b7-df17-4b84-9883-bb1e209d0ddb.gif)

![02_create_logo_client](https://user-images.githubusercontent.com/2551605/154867545-d1e55e29-08ab-4791-b124-943c3c8e19dd.gif)

![03_logos_propagated_to_report](https://user-images.githubusercontent.com/2551605/154867550-a700d1e7-d5be-4e19-8590-557d424ae20e.gif)

