### PR TITLE
Add info about Vault into report section

### DIFF
--- a/user-manual/reports/report-template-variables.md
+++ b/user-manual/reports/report-template-variables.md
@@ -17,6 +17,6 @@ When you are designing your pentest project template, you can reference a number
 |users|Project's users|full_name, short_bio, email, role|
 |targets|Project's targets|name, kind, tags|
 |findingsOverview|Findings stats|severity, count|
-|vulnerabilities|Project's vulnerabilities|summary, description, risk, remediation, status, cvss_score, cvss_vector, proof_of_concept|
+|vulnerabilities|Project's vulnerabilities|summary, description, risk, remediation, status, cvss_score, cvss_vector, proof_of_concept, owasp_vector, owasp_overall|
 |revisionHistoryDateTime|Report's revisions|dateTime, versionName, versionDescription|
-
+|vault| Project's vault | name, note, type |


### PR DESCRIPTION
Add vault functionality.

## Short description:
This enhancement provides a capability to safely store the project's related secret. Like discovered or obtained passwords, tokens or even generic note related to project.

## About implementation
I am using the openssl_encrypt/openssl_decrypt methods to encrypt the secret and store it in the database. The used algorithm is 'AES-256-CTR'.
I intentionaly allow to delete the secret without knowledge of password. It is because even during the development, I several times forgot the temporary password, which was used to the encryption.

Each item in vault contains flag if it should be reportable. If it is so, then the name and note about the secret are reported in the final report. I decided to not put the secret value itself into the report. It would cause to many issues: when to ask for the password? How to prevent anybody to access generated report with passwords? and similar. This way, we can report which accounts were compromised and if needed, the passwords can be extracted manually.


I tried to cover all controllers with the unit tests.

## Examples

https://user-images.githubusercontent.com/2551605/156604531-3114942c-bff0-4343-8dbc-4730fff05cef.mov


https://user-images.githubusercontent.com/2551605/156604587-a21c7d8c-ac0d-411e-ba57-ce3befe46a9a.mov

https://user-images.githubusercontent.com/2551605/156604640-1df35c3f-3345-47fa-9a23-b1b40786f96e.mov



## Related PRs
https://github.com/reconmap/web-client/pull/137
https://github.com/reconmap/rest-api/pull/39