### PR TITLE
Updated Documentation to reflect name change scheme

### DIFF
--- a/admin-manual/configuring-database-settings.md
+++ b/admin-manual/configuring-database-settings.md
@@ -11,11 +11,11 @@ Edit the content of the file to show (adjusting the values accordingly):
 
 ```json
 {
-	"database": {
-		"host": "db",
-		"username": "reconmapper",
-		"password": "reconmapped",
-		"name": "reconmap"
-	}
+    "database": {
+        "host": "rmap-mysql",
+        "username": "reconmapper",
+        "password": "reconmapped",
+        "name": "reconmap"
+    },
 }
 ```


### PR DESCRIPTION
The mysql hostname changed in a recent version but is still listed as "db" in the documentation 